### PR TITLE
Support Grasscutter 1.6.0+

### DIFF
--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -5,6 +5,7 @@
   "authors": [
     "hamusuke2303"
   ],
+  "api": 2,
   "mainClass": "com.hamusuke.killitems.Main",
   "comments": [
     "No comments"


### PR DESCRIPTION
Adds api version so the plugin loads on Grasscutter 1.6.x and newer versions.

Fixes #3 